### PR TITLE
Improving compliance with jasmine best practices

### DIFF
--- a/src/fuzzTest.js
+++ b/src/fuzzTest.js
@@ -3,11 +3,17 @@ global.fuzz = global.fuzz || {};
 function fuzzTest(name, fuzzer, testRunner) {
     const iterations = global.fuzz.iterations || 100;
 
-    const testCase = index => test(`${name} -> FUZZ-${index}`, () => testRunner(fuzzer()));
+    const testCase = index => {
+        test(`FUZZ-${index}`, () => {
+            testRunner(fuzzer())
+        })
+    };
 
-    for (let i = 0; i < iterations; i += 1) {
-        describe(name, testCase.bind(null, i));
-    }
+    describe(name, () => {
+        for (let i = 0; i < iterations; i += 1) {
+            testCase(i);
+        }
+    });
 }
 
 module.exports = fuzzTest;


### PR DESCRIPTION
I've made some changes to the `Fuzz.test(...)` implementation, to fix an issue where jasmine expects the runner functions passed to `describe(name,runner)` and to `test(name, runner)` to not return a value.

I also changed the name generation, so that the described name and test name are not massively duplicates of each other.

It would be nice if a `@types/jest-fuzz` could be provided, so that `jest-fuzz` could be used for Typescript projects... I'll let you know if I end up authoring such myself.